### PR TITLE
Create default config dir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cron"
+name = "crond"
 version = "0.1.0"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cron
+# crond
 
 A simple scheduler job runner
 
@@ -20,7 +20,6 @@ envs = {"FOO"="BAR","FOO1"="BAR1"}
 ## Usage
 
 ```sh
-mkdir -p ~/.config/cron
-vim ~/.config/cron/config.toml
-cron
+vim ~/.config/crond/config.toml
+crond
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ envs = {"FOO"="BAR","FOO1"="BAR1"}
 
 ```
 
+## Install
+
+```sh
+cargo install --git https://github.com/Akagi201/crond.git
+```
+
 ## Usage
 
 ```sh

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,7 @@ impl Config {
       if !config_dir.exists() {
         std::fs::create_dir_all(&config_dir).expect("Failed to create config directory");
       }
-      home_dir.join("config.toml")
+      config_dir.join("config.toml")
     });
     let c = FileConfig::builder()
       .add_source(File::from(config))

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,11 +30,16 @@ impl Config {
   pub fn new(config: Option<PathBuf>) -> Result<Self, ConfigError> {
     let config = config.unwrap_or_else(|| {
       let home_dir = homedir::my_home().expect("Failed to get home directory").unwrap();
-      home_dir.join(".config/cron/config.toml")
+      let config_dir = home_dir.join(".config/crond");
+      // create directory if it doesn't exist
+      if !config_dir.exists() {
+        std::fs::create_dir_all(&config_dir).expect("Failed to create config directory");
+      }
+      home_dir.join("config.toml")
     });
     let c = FileConfig::builder()
       .add_source(File::from(config))
-      .add_source(Environment::with_prefix("CRON"))
+      .add_source(Environment::with_prefix("CROND"))
       .build()?;
     c.try_deserialize()
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the package name from "cron" to "crond."
	- Added installation instructions for the scheduler using Cargo from a Git repository.

- **Documentation**
	- Revised README.md to reflect the new name "crond" throughout, including configuration paths and usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->